### PR TITLE
Update Ubuntu to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Basic Python3.6 install
-FROM ubuntu:yakkety
+FROM ubuntu:18.04
 
 RUN apt-get -y update && apt-get install -y python3.6 python3-pip
 


### PR DESCRIPTION
The Ubuntu yakkety build does not work with Docker when I run `docker build . -t python_src`:

> Ign:43 http://archive.ubuntu.com/ubuntu yakkety-backports/restricted all Packages
> Reading package lists...
> W: The repository 'http://security.ubuntu.com/ubuntu yakkety-security Release' does not have a Release file.
> W: The repository 'http://archive.ubuntu.com/ubuntu yakkety Release' does not have a Release file.
> W: The repository 'http://archive.ubuntu.com/ubuntu yakkety-updates Release' does not have a Release file.
> W: The repository 'http://archive.ubuntu.com/ubuntu yakkety-backports Release' does not have a Release file.
> E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/yakkety-security/universe/source/Sources  404  Not Found [IP: 91.189.88.161 80]
> E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/yakkety/universe/source/Sources  404  Not Found [IP: 91.189.88.152 80]
> E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/yakkety-updates/universe/source/Sources  404  Not Found [IP: 91.189.88.152 80]
> E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/yakkety-backports/restricted/binary-amd64/Packages  404  Not Found [IP: 91.189.88.152 80]
> E: Some index files failed to download. They have been ignored, or old ones used instead.
> The command '/bin/sh -c apt-get -y update && apt-get install -y python3.6 python3-pip' returned a non-zero code: 100

I'm not sure if this is the solution you'd prefer, but updating Ubuntu to the latest version works for me.